### PR TITLE
upgrade cloudformation-cli-python-lib to 2.1.3

### DIFF
--- a/apply/requirements.txt
+++ b/apply/requirements.txt
@@ -1,4 +1,4 @@
-cloudformation-cli-python-lib==2.0.0
+cloudformation-cli-python-lib==2.1.3
 ruamel.yaml
 requests
 awscli

--- a/get/requirements.txt
+++ b/get/requirements.txt
@@ -1,2 +1,2 @@
-cloudformation-cli-python-lib==2.0.0
+cloudformation-cli-python-lib==2.1.3
 awscli


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cloudformation-cli-python-plugin/issues/130
I'm using this project as part of the EKS QuickStart and right now I can't deploy the Application Load Balancer controller because of this problem.

*Description of changes:*
I've updated the plugin version to the latest one in order to fix the problem described in the above issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
