### PR TITLE
Ensure that we initialize handler before we run any kubectl commands.

### DIFF
--- a/apply/src/awsqs_kubernetes_resource/handlers.py
+++ b/apply/src/awsqs_kubernetes_resource/handlers.py
@@ -117,12 +117,12 @@ def update_handler(
     )
     if not proxy_needed(model.ClusterName, session):
         create_kubeconfig(model.ClusterName)
-    if not get_model(model, session):
-        raise exceptions.NotFound(TYPE_NAME, model.Uid)
     token, cluster_name, namespace, kind = decode_id(model.CfnId)
     _p, manifest_file, _d = handler_init(
         model, session, request.logicalResourceIdentifier, token
-    )
+    )        
+    if not get_model(model, session):
+        raise exceptions.NotFound(TYPE_NAME, model.Uid)
     cmd = f"kubectl apply -o yaml -f {manifest_file}"
     if model.Namespace:
         cmd = f"{cmd} -n {model.Namespace}"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #9 

*Description of changes:*
`manifest.yaml` should be initialized before we run any commands. Similar to create handler, we need to execute `handler_init` before anything else.   

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
