### PR TITLE
Split large kubectl output into multiple log messages

### DIFF
--- a/apply/src/awsqs_kubernetes_resource/handlers.py
+++ b/apply/src/awsqs_kubernetes_resource/handlers.py
@@ -118,11 +118,11 @@ def update_handler(
     if not proxy_needed(model.ClusterName, session):
         create_kubeconfig(model.ClusterName)
     if not get_model(model, session):
-        raise exceptions.NotFound(TYPE_NAME, model.Uid)
+        raise exceptions.NotFound(TYPE_NAME, model.Uid)        
     token, cluster_name, namespace, kind = decode_id(model.CfnId)
     _p, manifest_file, _d = handler_init(
         model, session, request.logicalResourceIdentifier, token
-    )
+    )        
     cmd = f"kubectl apply -o yaml -f {manifest_file}"
     if model.Namespace:
         cmd = f"{cmd} -n {model.Namespace}"
@@ -223,7 +223,7 @@ def run_command(command, cluster_name, session):
             put_function(session, cluster_name)
             with open("/tmp/manifest.yaml", "r") as fh:
                 resp = proxy_call(cluster_name, fh.read(), command, session)
-            LOG.info(resp)
+            log_output(resp)
             return resp
     retries = 0
     while True:
@@ -233,7 +233,7 @@ def run_command(command, cluster_name, session):
                 output = subprocess.check_output(
                     shlex.split(command), stderr=subprocess.STDOUT
                 ).decode("utf-8")
-                LOG.debug(output)
+                log_output(output)
             except subprocess.CalledProcessError as exc:
                 LOG.error(
                     "Command failed with exit code %s, stderr: %s"
@@ -389,3 +389,11 @@ def get_model(model, session):
             build_model([i], model)
             return model
     return None
+
+def log_output(output):
+    # CloudWatch PutEvents has a max length limit (256Kb)
+    # Use slightly smaller value to include supporting information (timestamp, log level, etc.)
+    limit = 260000 
+    output_string = f"{output}" # to support dictionaries as arguments
+    for m in [output_string[i:i+limit] for i in range(0, len(output_string), limit)]:
+        LOG.debug(m)

--- a/apply/src/awsqs_kubernetes_resource/handlers.py
+++ b/apply/src/awsqs_kubernetes_resource/handlers.py
@@ -118,11 +118,11 @@ def update_handler(
     if not proxy_needed(model.ClusterName, session):
         create_kubeconfig(model.ClusterName)
     if not get_model(model, session):
-        raise exceptions.NotFound(TYPE_NAME, model.Uid)        
+        raise exceptions.NotFound(TYPE_NAME, model.Uid)
     token, cluster_name, namespace, kind = decode_id(model.CfnId)
     _p, manifest_file, _d = handler_init(
         model, session, request.logicalResourceIdentifier, token
-    )        
+    )
     cmd = f"kubectl apply -o yaml -f {manifest_file}"
     if model.Namespace:
         cmd = f"{cmd} -n {model.Namespace}"


### PR DESCRIPTION
*Issue #, if available:*
Fixes #11 

*Description of changes:*
Split large kubectl output into multiple log messages

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
